### PR TITLE
feat: add external components

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "build:watch",
+            "isBackground": true,
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -209,16 +209,27 @@ import { TSDI, Component, External } from 'tsdi';
 @Component
 class A {}
 
+@Component
+class B {}
+
 @External()
-class B {
+class C {
   @Inject()
   public a: A;
+
+  public b: B;
+
+  constructor(@Inject() b: B) {
+    this.b = b;
+  }
+
+  @Initialize()
+  public init() {
+  }
 }
 
 const tsdi: TSDI = new TSDI();
 tsdi.enableComponentScanner();
-
-const a = (new B()).a;
 ```
 
 ## Future ideas / Roadmap

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Dependency Injection container (IoC) for TypeScript.
 * Constructor injection (parameters)
 * Singletons vs Instances
 * Factories
+* External components (components where the constructor could not be called by tsdi)
 
 # Usage
 
@@ -198,6 +199,26 @@ const tsdi: TSDI = new TSDI();
 tsdi.addProperty('config-key', 'config-value');
 tsdi.register(A);
 console.log(tsdi.get(A).some); // 'config-value'
+```
+
+### Externals
+
+```js
+import { TSDI, Component, External } from 'tsdi';
+
+@Component
+class A {}
+
+@External()
+class B {
+  @Inject()
+  public a: A;
+}
+
+const tsdi: TSDI = new TSDI();
+tsdi.enableComponentScanner();
+
+const a = (new B()).a;
 ```
 
 ## Future ideas / Roadmap

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -87,6 +87,7 @@ function addKnownExternal(external: Function): void {
 function addListener(listener: ComponentListener): void {
   listeners.push(listener);
   knownComponents.forEach(metadata => listener(metadata));
+  knownExternals.forEach(external => listener(external));
 }
 
 function removeListener(listener: ComponentListener): void {

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -243,7 +243,7 @@ export class TSDI {
     this.injectIntoInstance(instance, {fn: target, options: {}});
     const init: string = Reflect.getMetadata('component:init', target.prototype);
     if (init) {
-      (instance as any)[init].call(instance);
+      instance[init].call(instance);
     }
     return instance;
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "release": "standard-version",
     "postrelease": "git push --follow-tags origin master && npm publish",
     "precoverage": "npm run clean && tsc --inlineSourceMap",
-    "coverage": "nyc report --reporter=lcov && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
+    "coverage": "nyc report --reporter=lcov && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
+    "build:watch": "npm run build -- --watch"
   },
   "author": {
     "name": "Markus Wolf",

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import 'source-map-support/register';
 
-import { TSDI, Component, Inject, Factory } from '../lib/decorators';
+import { TSDI, Component, Inject, Factory, External } from '../lib/decorators';
 import { Dependency } from './dependency';
 import { User } from './user';
 
@@ -253,6 +253,21 @@ describe('TSDI', () => {
       }
 
       assert.strictEqual(tsdi.get(ComponentWithNonNamedInject).comp, tsdi.get(InjectedComponent));
+    });
+
+    describe('with external classes', () => {
+      it('should inject dependencies', () => {
+        tsdi.enableComponentScanner();
+
+        @External()
+        class ExternalClass {
+          @Inject()
+          public injected: User;
+        }
+
+        const external = new ExternalClass();
+        assert.equal(external.injected, tsdi.get(User));
+      });
     });
   });
 


### PR DESCRIPTION
Add support for external components. This is build as a decorator which
wraps around the class constructor to inject code after the class is
created by an external library.