### PR TITLE
fix: do not autoname components

### DIFF
--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -325,9 +325,6 @@ export function Component(optionsOrString: IComponentOptions | string = {}): Cla
   return function<TFunction extends Function>(target: TFunction): TFunction {
     // console.log(`@Component ${(target as any).name}`);
     const options = getNamedOptions<IComponentOptions>(optionsOrString);
-    if (!options.name) {
-      options.name = (target as any).name;
-    }
     addKnownComponent({
       fn: target as any,
       options


### PR DESCRIPTION
Do not provide a default name for components, since this will break in
minified code bases.