### PR TITLE
external decorator: set constructor.displayName = target.name

### DIFF
--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -341,6 +341,7 @@ export function External(): ClassDecorator {
     const constructor = function InjectedConstructor(this: any, ...args: any[]): any {
       return (target as any).__tsdi__.configureExternal(args, target);
     };
+    (constructor as any).displayName = (target as any).name;
     constructor.prototype = target.prototype;
     return constructor as any;
   };


### PR DESCRIPTION
external decorator: set `constructor.displayName = target.name`

This is helpful when working with react and the dev-tools, so the decorated elements will have a proper name.