### PR TITLE
fix: keep static properties when using @external decorator

### DIFF
--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -373,7 +373,7 @@ export function External<TFunction extends Function>(...args: any[]): ClassDecor
     (constructor as any).displayName = (target as any).name;
 
     Object.getOwnPropertyNames(target)
-      .filter(prop => prop !== '__tsdi__' && prop !== 'name' && prop !== 'length')
+      .filter(prop => !(constructor as any)[prop] && prop !== 'length')
       .forEach(prop => (constructor as any)[prop] = (target as any)[prop]);
     return constructor as any;
   };

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -341,6 +341,7 @@ export function External(): ClassDecorator {
     const constructor = function InjectedConstructor(this: any, ...args: any[]): any {
       return (target as any).__tsdi__.configureExternal(args, target);
     };
+    (constructor as any).displayName = (target as any).name;
     constructor.prototype = target.prototype;
     return constructor as any;
   };

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -342,7 +342,10 @@ export function External(): ClassDecorator {
       return (target as any).__tsdi__.configureExternal(args, target);
     };
     (constructor as any).displayName = (target as any).name;
-    constructor.prototype = target.prototype;
+
+    Object.getOwnPropertyNames(target)
+      .filter(prop => prop !== '__tsdi__' && prop !== 'name' && prop !== 'length')
+      .forEach(prop => (constructor as any)[prop] = (target as any)[prop]);
     return constructor as any;
   };
 }

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -426,6 +426,20 @@ describe('TSDI', () => {
 
         assert.equal(new ExternalClass('value').injected, tsdi.get(User));
       });
+
+      it('should keep static methods and properties', () => {
+        tsdi.enableComponentScanner();
+        const noop = () => console.log('noop');
+
+        @External()
+        class ExternalClass {
+          public static user = 'test';
+          public static noop = noop;
+        }
+
+        assert.strictEqual(ExternalClass.user, 'test');
+        assert.strictEqual(ExternalClass.noop, noop);
+      });
     });
   });
 


### PR DESCRIPTION
at the moment, static properties will be lost when using the @external decorator.
this fix iterates them and copies the static properties to the constructor.