### PR TITLE
feat: allow injection overrides

### DIFF
--- a/lib/tsdi.ts
+++ b/lib/tsdi.ts
@@ -408,6 +408,12 @@ export class TSDI {
     return this.getOrCreate<T>(metadata, idx);
   }
 
+  public override(component: Constructable<any>, override: any): void {
+    const idx = this.getComponentMetadataIndex(component);
+    this.instances[idx] = override;
+    log('Override %o with %o', component, override);
+  }
+
 }
 
 export { component, Component } from './component';

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -409,6 +409,26 @@ describe('TSDI', () => {
       assert.equal(count, 1);
     });
 
+    it('should allow overriding a dependency', () => {
+      tsdi.enableComponentScanner();
+
+      @component
+      class Component {
+        public foo(): string {
+          return 'foo';
+        }
+      }
+
+      class ComponentOverride {
+        public foo(): string {
+          return 'foo-override';
+        }
+      }
+      tsdi.override(Component, new ComponentOverride());
+
+      assert.equal(tsdi.get(Component).foo(), 'foo-override');
+    });
+
     describe('with external classes', () => {
       it('should inject dependencies', () => {
         tsdi.enableComponentScanner();


### PR DESCRIPTION
To ease mocking and testing there is an override method which will
allow to define a replacement injection per dependency.