### PR TITLE
feat: add scopes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "github.autoPublish": true
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Dependency Injection container (IoC) for TypeScript.
 * [Eager components](#eager-components)
 * [Debug logging](#debug-logging)
 * [Automocks](#automocks)
+* [Scopes](#scopes)
 
 # Usage
 
@@ -420,6 +421,40 @@ class Baz {
 tsdi.enableAutomock(Bar);
 tsdi.get(Baz);
 ```
+
+### Scopes
+
+Scopes could be seen as lifecycle bounds for a managed dependency.
+By that it is meant that components with a defined scope are only as long as
+the scope is entered/valid.
+
+```js
+import { TSDI, component, destroy } from 'tsdi';
+
+@component({scope: 'some-scope'})
+class Foo {
+  @destroy
+  private close(): void {
+    // free resources...
+  }
+}
+
+tsdi.get(Foo); // <-- will throw since the scope was not entered
+tsdi.getScope('some-scope').enter();
+tsdi.get(Foo); // <-- will return a new Foo
+tsdi.getScope('some-scope').leave();
+// Foo is destructed
+tsdi.getScope('some-scope').enter();
+tsdi.get(Foo); // <-- will return a new Foo
+
+```
+
+Whenever a scope is left, the lifecycle callbacks are executed. In the above
+example the `close` method is invoked.
+
+__Note__: Currently it is valid to inject scoped components into unscoped
+components which will lead to stale dependencies, since TSDI does not clear out
+injected dependencies as components are destructed.
 
 ### Alternative Syntax
 

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -563,6 +563,73 @@ describe('TSDI', () => {
         assert.instanceOf(new ExternalClass(), Base);
       });
     });
+
+    describe('and scope', () => {
+
+      it('should create components for that scopes', () => {
+        tsdi.enableComponentScanner();
+
+        @component({scope: 'scope'})
+        class ComponentWithScope {
+        }
+
+        tsdi.getScope('scope').enter();
+        const instance = tsdi.get(ComponentWithScope);
+
+        assert.isDefined(instance);
+      });
+
+      it('should throw if scope is not enabled', () => {
+        tsdi.enableComponentScanner();
+
+        @component({scope: 'scope'})
+        class ComponentWithScope {
+        }
+
+        assert.throws(() => tsdi.get(ComponentWithScope));
+      });
+
+      it('should destroy instances when their scope was left', () => {
+        tsdi.enableComponentScanner();
+
+        let destructorCalled = false;
+
+        @component({scope: 'scope'})
+        class ComponentWithScope {
+          @destroy
+          private destroy(): void {
+            destructorCalled = true;
+          }
+        }
+
+        tsdi.getScope('scope').enter();
+        tsdi.get(ComponentWithScope);
+        tsdi.getScope('scope').leave();
+
+        assert.isTrue(destructorCalled);
+      });
+
+      it('should keep instances which are out of left scope', () => {
+        tsdi.enableComponentScanner();
+
+        let destructorCalled = false;
+
+        @component
+        class ComponentWithoutScope {
+          @destroy
+          private destroy(): void {
+            destructorCalled = true;
+          }
+        }
+
+        tsdi.getScope('scope').enter();
+        tsdi.get(ComponentWithoutScope);
+        tsdi.getScope('scope').leave();
+
+        assert.isFalse(destructorCalled);
+      });
+
+    });
   });
 
   describe('without container instance', () => {


### PR DESCRIPTION
Scopes add lifecycle handling to components in a fine granular way and could be used to remove components if a scope is left.
This will prevent memory leaks for long running applications which keep references to all created instances.