### PR TITLE
feat: better error reporting on disabled scope

### DIFF
--- a/lib/tsdi.ts
+++ b/lib/tsdi.ts
@@ -236,14 +236,14 @@ export class TSDI {
               && metadata.rtti === component);
   }
 
-  private throwComponentNotFoundError(component?: Constructable<any>, name?: string): void {
+  private throwComponentNotFoundError(component?: Constructable<any>, name?: string, additionalInfo?: string): void {
     if (component && !name) {
       name = (component as any).name;
     }
     if (!name) {
       name = 'unknown';
     }
-    throw new Error(`Component '${name}' not found`);
+    throw new Error(`Component '${name}' not found${additionalInfo ? `: ${additionalInfo}` : ''}`);
   }
 
   private getConstructorParameters(metadata: ComponentOrFactoryMetadata): any[] {
@@ -282,7 +282,8 @@ export class TSDI {
 
   private createComponent<T>(metadata: ComponentMetadata, idx: number): T {
     if (!this.hasEnteredScope(metadata)) {
-      this.throwComponentNotFoundError(metadata.fn);
+      this.throwComponentNotFoundError(metadata.fn, undefined,
+        `required scope '${metadata.options.scope}' is not enabled`);
     }
     log('create %o with %o', (metadata.fn as any).name, metadata.options);
     const constructor: Constructable<T> =  metadata.fn as any;

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -527,7 +527,8 @@ describe('TSDI', () => {
       tsdi.enableComponentScanner();
       const dependent = tsdi.get(Dependent);
 
-      assert.throws(() => dependent.dependency.value, "Component 'Dependency' not found");
+      assert.throws(() => dependent.dependency.value,
+        "Component 'Dependency' not found: required scope 'scope' is not enabled");
     });
 
     describe('with external classes', () => {
@@ -649,7 +650,8 @@ describe('TSDI', () => {
         class ComponentWithScope {
         }
 
-        assert.throws(() => tsdi.get(ComponentWithScope));
+        assert.throws(() => tsdi.get(ComponentWithScope),
+          "Component 'ComponentWithScope' not found: required scope 'scope' is not enabled");
       });
 
       it('should destroy instances when their scope was left', () => {


### PR DESCRIPTION
If a component is requested and required to have a scope
enabled, but the scope is not entered a hint is shown
to the user that the required scope is not enabled.