### PR TITLE
feat: add warning if scopes are probably missued

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postrelease": "git push --follow-tags origin master && npm publish",
     "precoverage": "npm run clean && tsc --inlineSourceMap",
     "coverage": "nyc report --reporter=lcov && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "build:watch": "npm run build:esm -- --watch"
+    "build:watch": "npm run build:cjs -- --watch"
   },
   "author": {
     "name": "Markus Wolf",


### PR DESCRIPTION
If a component with scope is injected into a component without
scope it could easily lead to stale injected references.
A warning is output in this case.