### PR TITLE
feat: implement async component initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Dependency Injection container (IoC) for TypeScript.
 * [Scopes](#scopes)
 * [Dynamic Injections](#dynamic-injections)
 * [StrictPropertyInitialization](#strictpropertyinitialization)
+* [Async Dependencies](#async-dependencies)
 
 # Usage
 
@@ -521,6 +522,41 @@ class Bar {
 Each decorator can be written in uppercase: `@Component()` as well as lowercase: `@component()` in order
 to stay more consistent with the rest of the Typescript ecosystem. Empty parens can be omitted, so
 `@component()` can be written as `@component`.
+
+### Async Dependencies
+
+Components can have `@initialize` methods which return a `Promise` (and hence are async).
+When injected into another component the depending component's `@initialize` method will be called
+after the dependencies initializer has resolved. This is for example usefull when injecting a
+something like a Database connection which needs asynchroneous setup code:
+
+```js
+import { component, inject } from 'tsdi';
+
+@component
+class DatabaseConnection {
+  public connection?:
+
+  @initialize
+  private async initialize() {
+    this.connection = await connectToDatabase();
+  }
+}
+
+@component
+class RestApi {
+  @inject private db!: DatabaseConnection;
+
+  @initialize
+  private initialize() {
+    // This initializer will be called after the database was injected.
+    console.log(this.db.connection.query('SELECT * FROM user'));
+  }
+}
+```
+
+This does not work with dynamic injections and will throw an error. Please note that async injections can not
+be lazy and will not be lazy by default.
 
 ## Future ideas / Roadmap
 

--- a/lib/initialize.ts
+++ b/lib/initialize.ts
@@ -7,6 +7,9 @@ export function Initialize(...args: any[]): MethodDecorator | void {
   const decorate = (target: Object, propertyKey: string | symbol) => {
     log('@Initialize %s#%s', (target.constructor as any).name, propertyKey);
     Reflect.defineMetadata('component:init', propertyKey, target);
+
+    const isAsync = Reflect.getMetadata('design:returntype', target, propertyKey) === Promise;
+    Reflect.defineMetadata('component:init:async', isAsync, target);
   };
   if (args.length > 0) {
     return decorate(args[0], args[1]);

--- a/lib/tsdi.ts
+++ b/lib/tsdi.ts
@@ -308,7 +308,7 @@ export class TSDI {
       const awaiter = this.waitForInjectInitializers(metadata);
       if (awaiter) {
         awaiter.then(() => {
-          this.addInitializerPromise(instance, (instance as any)[init].call(instance));
+          this.addInitializerPromise(instance, (instance as any)[init].call(instance) || Promise.resolve());
         });
       } else {
         this.addInitializerPromise(instance, (instance as any)[init].call(instance));
@@ -329,6 +329,7 @@ export class TSDI {
         return Promise.all(initializers);
       }
     }
+    return undefined;
   }
 
   private hasEnteredScope(metadata: ComponentMetadata): boolean {
@@ -399,6 +400,7 @@ export class TSDI {
       ? false
       : Reflect.getMetadata('component:init:async', metadata.fn.prototype) as boolean;
     if (async && inject.options.dynamic) {
+      // todo: message + test
       throw new Error(`Components with async initializer could not be injected dynamically`);
     }
     return async;

--- a/lib/tsdi.ts
+++ b/lib/tsdi.ts
@@ -264,7 +264,6 @@ export class TSDI {
 
   private getOrCreate<T>(metadata: ComponentOrFactoryMetadata, idx: number): T {
     log('> getOrCreate %o', metadata);
-    // todo: Use T here
     let instance = this.instances[idx] as T;
     if (!instance || !this.isSingleton(metadata)) {
       if (isFactoryMetadata(metadata)) {
@@ -322,6 +321,7 @@ export class TSDI {
     if (injects) {
       const initializers = injects.map(inject => {
         const [metadata, idx] = this.getInjectComponentMetadata(inject);
+        // todo: check if injected component has async initializer
         const injectedComponent = this.getOrCreate(metadata, idx);
         return this.getInitializerPromise(injectedComponent);
       });
@@ -400,8 +400,8 @@ export class TSDI {
       ? false
       : Reflect.getMetadata('component:init:async', metadata.fn.prototype) as boolean;
     if (async && inject.options.dynamic) {
-      // todo: message + test
-      throw new Error(`Components with async initializer could not be injected dynamically`);
+      throw new Error(`Injecting ${inject.type.name} into ${inject.target.constructor.name}#${inject.property
+        } must not be dynamic since ${inject.type.name} has an async initializer`);
     }
     return async;
   }

--- a/lib/tsdi.ts
+++ b/lib/tsdi.ts
@@ -280,6 +280,16 @@ export class TSDI {
     return instance;
   }
 
+  private addInitializerPromise(instance: any, value: Promise<void> | undefined): void {
+    if (value) {
+      Reflect.defineMetadata('tsdi:initialize:promise', value, instance);
+    }
+  }
+
+  private getInitializerPromise(instance: any): Promise<void> | undefined {
+    return Reflect.getMetadata('tsdi:initialize:promise', instance);
+  }
+
   private createComponent<T>(metadata: ComponentMetadata, idx: number): T {
     if (!this.hasEnteredScope(metadata)) {
       this.throwComponentNotFoundError(metadata.fn, undefined,
@@ -295,9 +305,30 @@ export class TSDI {
     this.injectIntoInstance(instance, false, metadata);
     const init: string = Reflect.getMetadata('component:init', metadata.fn.prototype);
     if (init) {
-      (instance as any)[init].call(instance);
+      const awaiter = this.waitForInjectInitializers(metadata);
+      if (awaiter) {
+        awaiter.then(() => {
+          this.addInitializerPromise(instance, (instance as any)[init].call(instance));
+        });
+      } else {
+        this.addInitializerPromise(instance, (instance as any)[init].call(instance));
+      }
     }
     return instance;
+  }
+
+  private waitForInjectInitializers(metadata: ComponentMetadata): Promise<void[]> | undefined {
+    const injects: InjectMetadata[] = Reflect.getMetadata('component:injects', metadata.fn.prototype);
+    if (injects) {
+      const initializers = injects.map(inject => {
+        const [metadata, idx] = this.getInjectComponentMetadata(inject);
+        const injectedComponent = this.getOrCreate(metadata, idx);
+        return this.getInitializerPromise(injectedComponent);
+      });
+      if (initializers.some(initializer => Boolean(initializer))) {
+        return Promise.all(initializers);
+      }
+    }
   }
 
   private hasEnteredScope(metadata: ComponentMetadata): boolean {
@@ -334,7 +365,10 @@ export class TSDI {
     if (this.injectAutoMock(instance, inject)) {
       return;
     }
-    if (inject.options.lazy || inject.options.dynamic) {
+
+    const isAsyncInjection = this.isAsyncInitializerDependency(inject);
+
+    if (!isAsyncInjection && (inject.options.lazy || inject.options.dynamic)) {
       const tsdi = this;
       Object.defineProperty(instance, inject.property, {
         configurable: true,
@@ -357,6 +391,17 @@ export class TSDI {
     } else {
       instance[inject.property] = this.getComponentDependency(inject, componentMetadata, externalInstance);
     }
+  }
+
+  private isAsyncInitializerDependency(inject: InjectMetadata): boolean {
+    const [metadata] = this.getInjectComponentMetadata(inject);
+    const async = isFactoryMetadata(metadata)
+      ? false
+      : Reflect.getMetadata('component:init:async', metadata.fn.prototype) as boolean;
+    if (async && inject.options.dynamic) {
+      throw new Error(`Components with async initializer could not be injected dynamically`);
+    }
+    return async;
   }
 
   private injectAutoMock(instance: any, inject: InjectMetadata): boolean {

--- a/lib/tsdi.ts
+++ b/lib/tsdi.ts
@@ -534,7 +534,15 @@ export class TSDI {
     if (!metadata) {
       this.throwComponentNotFoundError(component, hint);
     }
-    return this.getOrCreate<T>(metadata, idx);
+    const instance = this.getOrCreate<T>(metadata, idx);
+    if (!isFactoryMetadata(metadata)) {
+      const isAsync = Reflect.getMetadata('component:init:async', metadata.fn.prototype) as boolean;
+      if (isAsync) {
+        console.warn(`Component '${metadata.fn.name}' is marked as asynchronous. `
+          + `It may not be proper initialized when accessed via get()`);
+      }
+    }
+    return instance;
   }
 
   public override(component: Constructable<any>, override: any): void {

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -252,6 +252,44 @@ describe('TSDI', () => {
       tsdi.get(Dependent);
     });
 
+    it('should call the initializer after  async dependencies w/o initializers are initialized', done => {
+      tsdi.enableComponentScanner();
+
+      @component
+      class DeepNestedAsyncDependency {
+        public value?: number;
+
+        @initialize
+        protected async init(): Promise<void> {
+          return new Promise<void>(resolve => {
+            setTimeout(() => {
+              this.value = 10;
+              resolve();
+            }, 10);
+          });
+        }
+      }
+
+      @component
+      class SyncDependency {
+        @inject public dependency!: DeepNestedAsyncDependency;
+      }
+
+      @component
+      class Dependent {
+        @inject public dependency!: SyncDependency;
+
+        @initialize
+        protected init(): void {
+          assert.equal(this.dependency.dependency.value, 10);
+          done();
+        }
+      }
+
+      // todo: this must throw because Dependent is async
+      tsdi.get(Dependent);
+    });
+
     it('should call the initalizer if all injections are itself initialized', done => {
       // this case test the case with async initializers
 

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -254,7 +254,8 @@ describe('TSDI', () => {
 
     it('should call the initalizer if all injections are itself initialized', done => {
       // this case test the case with async initializers
-      tsdi.enableComponentScanner();
+
+      let testValue: number | undefined;
 
       @component
       class Dependency {
@@ -269,20 +270,23 @@ describe('TSDI', () => {
           });
         }
       }
+      tsdi.register(Dependency);
 
-      @component
+      @component({eager: true})
       class Dependent {
         @inject private dependency!: Dependency;
 
         @initialize
         protected init(): void {
-          assert.equal(this.dependency.value, 10);
-          done();
+          testValue = this.dependency.value;
         }
       }
+      tsdi.register(Dependent);
 
-      // todo: this must throw because Dependent is async
-      tsdi.get(Dependent);
+      setTimeout(() => {
+        assert.equal(testValue, 10);
+        done();
+      }, 15);
     });
 
     it('should throw if async initializer dependency is injected dynamically', () => {

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -207,6 +207,39 @@ describe('TSDI', () => {
       assert.isTrue(called);
     });
 
+    it('should call the initalizer if all injections are itself initialized', done => {
+      // this case test the case with async initializers
+      tsdi.enableComponentScanner();
+
+      @component
+      class Dependency {
+        public value?: number;
+        @initialize
+        protected async init(): Promise<void> {
+          return new Promise<void>(resolve => {
+            setTimeout(() => {
+              this.value = 10;
+              resolve();
+            }, 100);
+          });
+        }
+      }
+
+      @component
+      class Dependent {
+        @inject private dependency!: Dependency;
+
+        @initialize
+        protected init(): void {
+          assert.equal(this.dependency.value, 10);
+          done();
+        }
+      }
+
+      // todo: this must throw because Dependent is async
+      tsdi.get(Dependent);
+    });
+
     it('should inject annotated constructor parameters', () => {
       tsdi.enableComponentScanner();
 

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -706,54 +706,6 @@ describe('TSDI', () => {
           'Injecting Dependency into Dependent#dependency must not '
             + 'be dynamic since Dependency has an async initializer');
       });
-
-      it('should call the initializer of an async dependency with a factory', done => {
-        tsdi.enableComponentScanner();
-
-        class Instanced {
-          public value?: number;
-
-          constructor(value: number) {
-            this.value = value;
-          }
-        }
-
-        // @ts-ignore
-        @component
-        // @ts-ignore
-        class AsyncFactory {
-          private instance!: Instanced;
-
-          @initialize
-          protected async init(): Promise<void> {
-            return new Promise<void>(resolve => {
-              setTimeout(() => {
-                this.instance = new Instanced(10);
-                resolve();
-              }, 10);
-            });
-          }
-
-          @factory
-          public getInstance(): Instanced {
-            return this.instance;
-          }
-        }
-
-        @component
-        class Dependent {
-          @inject public instance!: Instanced;
-
-          @initialize
-          protected init(): void {
-            assert.equal(this.instance.value, 10);
-            done();
-          }
-        }
-
-        // todo: this must throw because Dependent is async
-        tsdi.get(Dependent);
-      });
     });
 
     describe('with external classes', () => {

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -207,6 +207,51 @@ describe('TSDI', () => {
       assert.isTrue(called);
     });
 
+    it('should call the initializer after multiple async dependencies are initialized', done => {
+      tsdi.enableComponentScanner();
+
+      @component
+      class DeepNestedAsyncDependency {
+        public value?: number;
+
+        @initialize
+        protected async init(): Promise<void> {
+          return new Promise<void>(resolve => {
+            setTimeout(() => {
+              this.value = 10;
+              resolve();
+            }, 10);
+          });
+        }
+      }
+
+      @component
+      class SyncDependency {
+        @inject public dependency!: DeepNestedAsyncDependency;
+        public value?: number;
+
+        @initialize
+        protected init(): void {
+          assert.equal(this.dependency.value, 10);
+          this.value = 10;
+        }
+      }
+
+      @component
+      class Dependent {
+        @inject public dependency!: SyncDependency;
+
+        @initialize
+        protected init(): void {
+          assert.equal(this.dependency.value, 10);
+          done();
+        }
+      }
+
+      // todo: this must throw because Dependent is async
+      tsdi.get(Dependent);
+    });
+
     it('should call the initalizer if all injections are itself initialized', done => {
       // this case test the case with async initializers
       tsdi.enableComponentScanner();


### PR DESCRIPTION
Since components may require async initializers
(e.g. to connect to some resource) the dependency
tree could only be created async in some cases.
To support this tsdi calls component initializers
only if all injected component initializers are done.

There are a few parts missing in this implementation.

- [x] Warn if usage is not correct
- [x] Fail to synchronously get asyncronous components
- [x] Check that components are still created lazily
- [x] Add test for async dependency tree with depth > 1
- [x] Add documentation for this feature (works only if function is declared as `async`)

Closes #208 