### PR TITLE
fix: use default import for debug

### DIFF
--- a/lib/component.ts
+++ b/lib/component.ts
@@ -1,8 +1,8 @@
+import debug from 'debug';
 import { addKnownComponent } from './global-state';
 import { getNamedOptions } from './helper';
 import { IComponentOptions } from './tsdi';
 
-import * as debug from 'debug';
 const log = debug('tsdi');
 
 export function Component(

--- a/lib/destroy.ts
+++ b/lib/destroy.ts
@@ -1,4 +1,4 @@
-import * as debug from 'debug';
+import debug from 'debug';
 const log = debug('tsdi');
 
 export function Destroy(target: object, propertyKey: string): void;

--- a/lib/external.ts
+++ b/lib/external.ts
@@ -1,7 +1,7 @@
+import debug from 'debug';
 import { addKnownExternal } from './global-state';
-
-import * as debug from 'debug';
 import { TSDI } from './tsdi';
+
 const log = debug('tsdi');
 
 // tslint:disable-next-line:ban-types

--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -1,7 +1,7 @@
+import debug from 'debug';
 import { addKnownComponent } from './global-state';
 import { IFactoryOptions } from './tsdi';
 
-import * as debug from 'debug';
 const log = debug('tsdi');
 
 export function Factory(target: object, propertyKey: string): void;

--- a/lib/initialize.ts
+++ b/lib/initialize.ts
@@ -1,4 +1,4 @@
-import * as debug from 'debug';
+import debug from 'debug';
 const log = debug('tsdi');
 
 export function Initialize(target: object, propertyKey: string): void;

--- a/lib/inject.ts
+++ b/lib/inject.ts
@@ -1,12 +1,12 @@
+import debug from 'debug';
 import { getNamedOptions } from './helper';
 import {
-  IInjectOptions,
   Constructable,
+  IInjectOptions,
   InjectMetadata,
   ParameterMetadata
 } from './tsdi';
 
-import * as debug from 'debug';
 const log = debug('tsdi');
 
 export function Inject(

--- a/lib/tsdi.ts
+++ b/lib/tsdi.ts
@@ -1,4 +1,4 @@
-import * as debug from 'debug';
+import debug from 'debug';
 import 'reflect-metadata';
 import { addListener, ComponentListener, removeListener } from './global-state';
 import { findIndexOf, isFactoryMetadata } from './helper';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,7 @@
     "target": "es5",
     "module": "es2015",
     "outDir": "dist/esm",
-    "lib": [
-      "es2015",
-      "es2016",
-      "es2017"
-    ],
+    "lib": ["es2015", "es2016", "es2017"],
     "strict": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
@@ -20,11 +16,9 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "pretty": true
+    "pretty": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   },
-  "exclude": [
-    "node_modules",
-    "dist",
-    "index.d.ts"
-  ]
+  "exclude": ["node_modules", "dist", "index.d.ts"]
 }


### PR DESCRIPTION
Since TS 2.7 esModuleInterop should be used
to mitigate import problems with commonjs
modules which does not have a default export.

Closes #312