### PR TITLE
chore: only prettify ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     ]
   },
   "lint-staged": {
-    "**/*": [
+    "**/*.{ts,tsx}": [
       "prettier --list-different"
     ],
     "lib/**/*.{ts,tsx}": [


### PR DESCRIPTION
We ignore prettier for markdown and json files which will fail shipjs
otherwise.