### PR TITLE
chore: build before test and publish with default cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf .nyc_output coverage dist dist-tests",
     "prebuild": "yarn clean",
     "build": "microbundle",
-    "pretest": "tsc --project ./tests/tsconfig.json",
+    "pretest": "yarn build && tsc --project ./tests/tsconfig.json",
     "test": "nyc --reporter=text --reporter=lcov mocha dist-tests",
     "coverage": "nyc report --reporter=lcov && codecov",
     "release:prepare": "shipjs prepare",

--- a/ship.config.js
+++ b/ship.config.js
@@ -2,6 +2,5 @@ module.exports = {
   mergeStrategy: {
     toSameBranch: ['master', 'release/0.20']
   },
-  getStagingBranchName: ({ nextVersion }) => `release-v${nextVersion}`,
-  publishCommand: () => 'npm publish'
+  getStagingBranchName: ({ nextVersion }) => `release-v${nextVersion}`
 };


### PR DESCRIPTION
Since shipjs does not build before test but after, we need
to compile everything with tests as well.