### PR TITLE
chore: trigger build on push and pull_request

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 name: Build and Test
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
To have shipjs releases trigger a build we need to listen to
pull_request events as well.