### PR TITLE
test: add usage with destroy() decorator

### DIFF
--- a/lib/__integration__/tsconfig.json
+++ b/lib/__integration__/tsconfig.json
@@ -8,5 +8,6 @@
     "baseUrl": "../../node_modules",
     "types": ["cypress"],
     "skipLibCheck": true
-  }
+  },
+  "exclude": []
 }

--- a/lib/__tests__/index-test.ts
+++ b/lib/__tests__/index-test.ts
@@ -756,7 +756,7 @@ describe('TSDI', () => {
 
       @component
       class ComponentWithDestructor {
-        @destroy
+        @destroy()
         public foo(): void {
           destructorCalled = true;
         }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "exclude": [
       "wallaby.js",
       "website/",
-      "tests/integration/"
+      "lib/__integration__/"
     ]
   },
   "husky": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,6 @@
     "esModuleInterop": true,
     "sourceMap": true
   },
-  "include": ["lib/"]
+  "include": ["lib/"],
+  "exclude": ["lib/__integration__"]
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,7 +1,7 @@
 module.exports = function (wallaby) {
   return {
     trace: true,
-    files: ['lib/**', '!lib/__tests__/*-test.ts'],
+    files: ['lib/**', '!lib/__integration__/**', '!lib/__tests__/*-test.ts'],
     tests: ['lib/__tests__/*-test.ts'],
     testFramework: 'mocha',
     env: {


### PR DESCRIPTION
This one was missing in the current coverage.
