### PR TITLE
chore: drop support for node 10 and 12

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '10']
+        node: ['14', '16']
     name: Test using node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
BREAKING CHANGE: Drop support for node 10 and 12
